### PR TITLE
fix: manifest attribute "command" can't start job, changed to "args"

### DIFF
--- a/Job.yaml
+++ b/Job.yaml
@@ -14,5 +14,5 @@ spec:
       containers:
       - name: c
         image: devopscube/kubernetes-job-demo:latest
-        command: ["100"]
+        args: ["100"]
       restartPolicy: Never


### PR DESCRIPTION
Hi, 

I tried running this yaml on k8s v1.22

however, the manifest needs an args, not a command

to exec:
```
kubectl apply -f example.yaml
```